### PR TITLE
Use Horizon auth with owner Gmail token

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,16 +1,10 @@
-# Google OAuth web client for FastMCP MCP authentication.
+# Google OAuth client used by the server to refresh the owner's Gmail token.
 GOOGLE_OAUTH_CLIENT_ID=your-web-client-id.apps.googleusercontent.com
 GOOGLE_OAUTH_CLIENT_SECRET=your-web-client-secret
 
-# Public base URL of this MCP server.
-# Localhost example:
-GMAIL_MCP_BASE_URL=http://127.0.0.1:8000
-# Horizon example:
-# GMAIL_MCP_BASE_URL=https://your-server-name.fastmcp.app
+# Refresh token for the owner Gmail identity.
+# Generate this once locally through Google OAuth with gmail.send/gmail.modify scopes.
+GOOGLE_OAUTH_REFRESH_TOKEN=your-owner-gmail-refresh-token
 
-# The only Gmail address allowed to connect and operate Gmail tools.
+# The Gmail address that the refresh token must belong to.
 ALLOWED_GMAIL_EMAIL=your@gmail.com
-
-# Stable signing key for FastMCP's OAuth proxy tokens.
-# Use a long random value in real deployments.
-FASTMCP_JWT_SIGNING_KEY=replace-with-a-long-random-secret

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,7 +1,7 @@
 # Gmail MCP Server
 
-A remote MCP server that lets an allowed Gmail owner compose and send mail
-through Gmail after authenticating with Google OAuth.
+A remote MCP server that lets Horizon-authorized callers compose and send mail
+through one configured owner Gmail identity.
 
 ## Language
 
@@ -10,23 +10,27 @@ An MCP server deployed to remote hosting that performs Gmail operations for one 
 _Avoid_: Local Gmail agent, multi-user Gmail server
 
 **Allowed Gmail Identity**:
-The only Gmail User permitted to authenticate to and operate the Single-User Remote Gmail Agent.
+The Gmail User whose mailbox the Single-User Remote Gmail Agent operates.
 _Avoid_: Any Google user, shared Gmail user
 
 **MCP Access Identity**:
-The Google-authenticated identity of the caller allowed to connect to the remote MCP server.
+The Horizon-authenticated identity of the caller allowed to connect to the remote MCP server.
 _Avoid_: Gmail token store user, local current user
 
 **Google OAuth Client Credentials**:
-The Google Cloud web OAuth client configuration used by FastMCP to authenticate MCP clients and request Gmail scopes.
+The Google Cloud OAuth client configuration used to refresh the owner Gmail token.
 _Avoid_: Desktop credentials, local credentials file
+
+**Owner Gmail Refresh Token**:
+A Google OAuth refresh token for the Allowed Gmail Identity stored as a Horizon environment secret.
+_Avoid_: MCP access token, Horizon token
 
 **Gmail User**:
 The Google account whose Gmail mailbox is operated by the server.
 _Avoid_: Account, profile
 
 **Gmail Session**:
-Ready-to-use Gmail capability created from the current request's Google OAuth access token.
+Ready-to-use Gmail capability created from the Owner Gmail Refresh Token.
 _Avoid_: Credentials, client
 
 **Gmail Session Factory**:
@@ -36,26 +40,26 @@ _Avoid_: Token store, auth manager
 ## Relationships
 
 - A **Single-User Remote Gmail Agent** has exactly one **Allowed Gmail Identity**.
-- A **Single-User Remote Gmail Agent** derives its **MCP Access Identity** from Google OAuth.
-- A **Single-User Remote Gmail Agent** allows Gmail operations only for the **Allowed Gmail Identity**.
-- A **Single-User Remote Gmail Agent** verifies the **Allowed Gmail Identity** on every Gmail operation.
-- A **Single-User Remote Gmail Agent** requests only email identity, Gmail send, and Gmail modify Google OAuth scopes.
-- A **Gmail Session** belongs to the **MCP Access Identity** for the current request.
-- A **Gmail Session Factory** creates a **Gmail Session** from the current request's Google OAuth access token.
+- A **Single-User Remote Gmail Agent** receives MCP access through Horizon authentication.
+- A **Single-User Remote Gmail Agent** uses the **Owner Gmail Refresh Token** for Gmail API calls.
+- An **Owner Gmail Refresh Token** must belong to the **Allowed Gmail Identity**.
+- An **Owner Gmail Refresh Token** requests only Gmail send and Gmail modify Google OAuth scopes.
+- A **Gmail Session** belongs to the configured **Allowed Gmail Identity**.
+- A **Gmail Session Factory** creates a **Gmail Session** from the **Owner Gmail Refresh Token**.
 - The server no longer supports local stdio mode or a local Gmail token store.
 
 ## Example Dialogue
 
 > **Dev:** "Can anyone with the Horizon URL send mail?"
-> **Domain expert:** "No. The server requires Google OAuth and only the **Allowed Gmail Identity** can use Gmail tools."
+> **Domain expert:** "No. Horizon authentication controls who can connect to the MCP server."
 >
 > **Dev:** "Does the server keep refresh tokens in `~/.gmail-mcp/`?"
-> **Domain expert:** "No. Local stdio mode has been decommissioned; Gmail operations use the current request's Google OAuth access token."
+> **Domain expert:** "No. Local stdio mode has been decommissioned; Gmail operations use the **Owner Gmail Refresh Token** from deployment secrets."
 >
 > **Dev:** "Should Horizon authentication also be enabled?"
-> **Domain expert:** "No. FastMCP Google OAuth protects the MCP endpoint directly for this server."
+> **Domain expert:** "Yes. Horizon authentication is the MCP access gate on the hosted deployment."
 
 ## Flagged Ambiguities
 
-- "auth" can mean MCP access authentication or Gmail API authorization. Current resolution: a single Google OAuth flow protects MCP access and grants Gmail send/modify scopes for the **Allowed Gmail Identity**.
+- "auth" can mean MCP access authentication or Gmail API authorization. Current resolution: Horizon authenticates MCP access, while Google OAuth refreshes Gmail API access for the **Allowed Gmail Identity**.
 - "remote Gmail server" was explored as both multi-user and single-user. Current target: a **Single-User Remote Gmail Agent** only.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Gmail MCP Server
 
-A remote FastMCP server for sending Gmail messages through a single allowed
-Gmail identity. The server is designed for Prefect Horizon and is protected by
-Google OAuth at MCP connection time.
+A remote FastMCP server for sending Gmail messages through a single owner Gmail
+identity. The server is designed for Prefect Horizon and relies on Horizon's
+gateway authentication for MCP access.
 
 ## Features
 
-- Google OAuth MCP access with FastMCP `GoogleProvider`
-- Allowed Gmail identity enforcement on every Gmail operation
+- Horizon-managed MCP authentication
+- Server-owned Gmail refresh token for the owner Gmail identity
 - Gmail send, draft creation, draft listing, and draft sending tools
 - Professional email composition prompts, resources, and helper tools
 - Remote-only Horizon entry point at `main.py:mcp`
@@ -19,39 +19,25 @@ Deploy this repository to Prefect Horizon from the default branch.
 Configure Horizon with:
 
 - Entrypoint: `main.py:mcp`
-- Horizon authentication: disabled for this server, because FastMCP Google OAuth
-  protects the MCP endpoint directly
+- Horizon authentication: enabled
 
 Set these deployment environment variables:
 
-- `GOOGLE_OAUTH_CLIENT_ID`: Google OAuth web client ID
-- `GOOGLE_OAUTH_CLIENT_SECRET`: Google OAuth web client secret
-- `GMAIL_MCP_BASE_URL`: deployed server base URL, for example
-  `https://your-server-name.fastmcp.app`
-- `ALLOWED_GMAIL_EMAIL`: the only Gmail address allowed to connect and send
-  mail
-- `FASTMCP_JWT_SIGNING_KEY`: optional stable signing secret so clients do not
-  need to re-authenticate after every server restart
+- `GOOGLE_OAUTH_CLIENT_ID`: Google OAuth client ID for the owner Gmail token
+- `GOOGLE_OAUTH_CLIENT_SECRET`: Google OAuth client secret for the owner Gmail
+  token
+- `GOOGLE_OAUTH_REFRESH_TOKEN`: refresh token for the owner Gmail identity
+- `ALLOWED_GMAIL_EMAIL`: the Gmail address the refresh token must belong to
 
-The Google OAuth client must allow the FastMCP callback for the deployed base
-URL. By default FastMCP uses `/auth/callback`, so add:
+The Google OAuth refresh token must include these scopes:
 
 ```text
-https://your-server-name.fastmcp.app/auth/callback
-```
-
-The Google OAuth consent screen must include these scopes:
-
-```text
-openid
-https://www.googleapis.com/auth/userinfo.email
 https://www.googleapis.com/auth/gmail.send
 https://www.googleapis.com/auth/gmail.modify
 ```
 
-Only the Google account matching `ALLOWED_GMAIL_EMAIL` can use the Gmail tools.
-Other Google accounts may complete Google login, but Gmail operations are
-rejected server-side.
+Horizon controls who may connect to the MCP server. The backend uses the
+configured owner Gmail refresh token for Gmail API calls.
 
 ## Local Verification
 
@@ -66,9 +52,8 @@ Inspect the Horizon entry point with dummy local configuration:
 ```bash
 GOOGLE_OAUTH_CLIENT_ID=test.apps.googleusercontent.com \
 GOOGLE_OAUTH_CLIENT_SECRET=test \
-GMAIL_MCP_BASE_URL=http://localhost:8000 \
+GOOGLE_OAUTH_REFRESH_TOKEN=test-refresh-token \
 ALLOWED_GMAIL_EMAIL=owner@example.com \
-FASTMCP_JWT_SIGNING_KEY=test-signing-key \
 uv run fastmcp inspect main.py:mcp
 ```
 

--- a/docs/adr/0003-use-google-oauth-for-single-user-remote-access.md
+++ b/docs/adr/0003-use-google-oauth-for-single-user-remote-access.md
@@ -1,3 +1,0 @@
-# Use Google OAuth for Single-User Remote Access
-
-The remote deployment target is a **Single-User Remote Gmail Agent**, not a multi-user Gmail service. We will use Google OAuth as the MCP access gate and allow only the configured **Allowed Gmail Identity** to connect, so the public Horizon endpoint cannot be used to operate the owner's Gmail unless the caller authenticates as that Gmail identity.

--- a/docs/adr/0003-use-horizon-auth-with-owner-gmail-token.md
+++ b/docs/adr/0003-use-horizon-auth-with-owner-gmail-token.md
@@ -1,0 +1,3 @@
+# Use Horizon Auth with an Owner Gmail Token
+
+Horizon authentication is mandatory on the free hosted endpoint and sits in front of the backend MCP server, so backend FastMCP Google OAuth rejects Horizon gateway tokens. We will let Horizon authenticate MCP access and use a server-owned Google refresh token for the **Allowed Gmail Identity** to perform Gmail API operations.

--- a/remote.py
+++ b/remote.py
@@ -2,21 +2,8 @@
 
 import os
 
-from fastmcp.server.auth.providers.google import GoogleProvider
-
-from src.remote_auth import RemoteGoogleSessionFactory
+from src.remote_auth import OwnerGmailSessionFactory
 from src.server import create_server
-
-GOOGLE_IDENTITY_SCOPE = "https://www.googleapis.com/auth/userinfo.email"
-GMAIL_SEND_SCOPE = "https://www.googleapis.com/auth/gmail.send"
-GMAIL_MODIFY_SCOPE = "https://www.googleapis.com/auth/gmail.modify"
-
-REQUIRED_GOOGLE_SCOPES = [
-    "openid",
-    GOOGLE_IDENTITY_SCOPE,
-    GMAIL_SEND_SCOPE,
-    GMAIL_MODIFY_SCOPE,
-]
 
 
 def _required_env(name: str) -> str:
@@ -27,18 +14,14 @@ def _required_env(name: str) -> str:
 
 
 def create_remote_server():
-    """Create the Google-protected remote MCP server for Horizon."""
-    auth = GoogleProvider(
+    """Create the Horizon-hosted MCP server for the owner's Gmail identity."""
+    session_factory = OwnerGmailSessionFactory(
         client_id=_required_env("GOOGLE_OAUTH_CLIENT_ID"),
         client_secret=_required_env("GOOGLE_OAUTH_CLIENT_SECRET"),
-        base_url=_required_env("GMAIL_MCP_BASE_URL"),
-        required_scopes=REQUIRED_GOOGLE_SCOPES,
-        jwt_signing_key=os.environ.get("FASTMCP_JWT_SIGNING_KEY"),
-    )
-    session_factory = RemoteGoogleSessionFactory(
+        refresh_token=_required_env("GOOGLE_OAUTH_REFRESH_TOKEN"),
         allowed_gmail_email=_required_env("ALLOWED_GMAIL_EMAIL")
     )
-    return create_server(session_factory, auth=auth)
+    return create_server(session_factory)
 
 
 mcp = create_remote_server()

--- a/src/remote_auth.py
+++ b/src/remote_auth.py
@@ -1,33 +1,52 @@
-"""Remote Google OAuth session factory for Horizon deployments."""
+"""Server-owned Gmail session factory for Horizon deployments."""
 
 from google.oauth2.credentials import Credentials
 
-from fastmcp.server.dependencies import get_access_token
-
 from .gmail_session import GmailSession, GmailSessionFactory
 
+GMAIL_SEND_SCOPE = "https://www.googleapis.com/auth/gmail.send"
+GMAIL_MODIFY_SCOPE = "https://www.googleapis.com/auth/gmail.modify"
+GMAIL_SCOPES = [GMAIL_SEND_SCOPE, GMAIL_MODIFY_SCOPE]
+GOOGLE_TOKEN_URI = "https://oauth2.googleapis.com/token"
 
-class ForbiddenGmailIdentityError(Exception):
-    """Raised when the authenticated Google user is not the allowed Gmail user."""
 
+class OwnerGmailSessionFactory:
+    """Creates Gmail sessions from the owner's configured Google refresh token."""
 
-class RemoteGoogleSessionFactory:
-    """Creates Gmail sessions from the current FastMCP Google access token."""
-
-    def __init__(self, allowed_gmail_email: str):
+    def __init__(
+        self,
+        *,
+        client_id: str,
+        client_secret: str,
+        refresh_token: str,
+        allowed_gmail_email: str,
+    ):
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.refresh_token = refresh_token
         self.allowed_gmail_email = allowed_gmail_email.strip().lower()
         self._session_factory = GmailSessionFactory()
 
     def create_current_session(self) -> GmailSession | None:
-        token = get_access_token()
-        if token is None:
-            return None
-
-        email = str(token.claims.get("email") or "").strip().lower()
-        if email != self.allowed_gmail_email:
-            raise ForbiddenGmailIdentityError(
-                "Authenticated Google user is not allowed to use this Gmail server"
-            )
-
-        credentials = Credentials(token=token.token, scopes=token.scopes)
+        credentials = Credentials(
+            token=None,
+            refresh_token=self.refresh_token,
+            token_uri=GOOGLE_TOKEN_URI,
+            client_id=self.client_id,
+            client_secret=self.client_secret,
+            scopes=GMAIL_SCOPES,
+        )
         return self._session_factory.create_session(credentials)
+
+    def validate_allowed_identity(self) -> None:
+        """Fail fast if the configured Gmail token is not the allowed identity."""
+        session = self.create_current_session()
+        if session is None:
+            raise RuntimeError("Gmail owner credentials are not configured")
+
+        email = session.get_user_info()["email"].strip().lower()
+        if email != self.allowed_gmail_email:
+            raise RuntimeError(
+                "Configured Gmail refresh token does not belong to "
+                f"ALLOWED_GMAIL_EMAIL ({self.allowed_gmail_email})"
+            )

--- a/tests/test_remote_auth.py
+++ b/tests/test_remote_auth.py
@@ -1,51 +1,76 @@
-"""Tests for remote Google OAuth session creation."""
+"""Tests for server-owned Gmail session creation."""
 
-from types import SimpleNamespace
 from unittest.mock import MagicMock
 
-import pytest
-
-from src.remote_auth import ForbiddenGmailIdentityError, RemoteGoogleSessionFactory
-
-
-def test_remote_factory_returns_none_without_access_token(monkeypatch):
-    monkeypatch.setattr("src.remote_auth.get_access_token", lambda: None)
-
-    factory = RemoteGoogleSessionFactory("owner@example.com")
-
-    assert factory.create_current_session() is None
+from src.remote_auth import (
+    GMAIL_MODIFY_SCOPE,
+    GMAIL_SEND_SCOPE,
+    GOOGLE_TOKEN_URI,
+    OwnerGmailSessionFactory,
+)
 
 
-def test_remote_factory_rejects_unallowed_google_user(monkeypatch):
-    token = SimpleNamespace(
-        token="access-token",
-        scopes=["https://www.googleapis.com/auth/gmail.send"],
-        claims={"email": "other@example.com"},
-    )
-    monkeypatch.setattr("src.remote_auth.get_access_token", lambda: token)
-
-    factory = RemoteGoogleSessionFactory("owner@example.com")
-
-    with pytest.raises(ForbiddenGmailIdentityError):
-        factory.create_current_session()
-
-
-def test_remote_factory_creates_session_for_allowed_google_user(monkeypatch):
-    token = SimpleNamespace(
-        token="access-token",
-        scopes=["https://www.googleapis.com/auth/gmail.send"],
-        claims={"email": "Owner@Example.com"},
-    )
+def test_owner_factory_creates_session_from_refresh_token(monkeypatch):
     session = MagicMock()
-    monkeypatch.setattr("src.remote_auth.get_access_token", lambda: token)
     create_session = MagicMock(return_value=session)
     monkeypatch.setattr(
         "src.remote_auth.GmailSessionFactory.create_session", create_session
     )
 
-    factory = RemoteGoogleSessionFactory("owner@example.com")
+    factory = OwnerGmailSessionFactory(
+        client_id="client-id",
+        client_secret="client-secret",
+        refresh_token="refresh-token",
+        allowed_gmail_email="owner@example.com",
+    )
+
     result = factory.create_current_session()
 
     assert result is session
     credentials = create_session.call_args.args[0]
-    assert credentials.token == "access-token"
+    assert credentials.refresh_token == "refresh-token"
+    assert credentials.token_uri == GOOGLE_TOKEN_URI
+    assert credentials.client_id == "client-id"
+    assert credentials.client_secret == "client-secret"
+    assert credentials.scopes == [GMAIL_SEND_SCOPE, GMAIL_MODIFY_SCOPE]
+
+
+def test_validate_allowed_identity_accepts_matching_owner(monkeypatch):
+    session = MagicMock()
+    session.get_user_info.return_value = {"email": "Owner@Example.com"}
+    monkeypatch.setattr(
+        "src.remote_auth.OwnerGmailSessionFactory.create_current_session",
+        lambda self: session,
+    )
+
+    factory = OwnerGmailSessionFactory(
+        client_id="client-id",
+        client_secret="client-secret",
+        refresh_token="refresh-token",
+        allowed_gmail_email="owner@example.com",
+    )
+
+    factory.validate_allowed_identity()
+
+
+def test_validate_allowed_identity_rejects_mismatched_owner(monkeypatch):
+    session = MagicMock()
+    session.get_user_info.return_value = {"email": "other@example.com"}
+    monkeypatch.setattr(
+        "src.remote_auth.OwnerGmailSessionFactory.create_current_session",
+        lambda self: session,
+    )
+
+    factory = OwnerGmailSessionFactory(
+        client_id="client-id",
+        client_secret="client-secret",
+        refresh_token="refresh-token",
+        allowed_gmail_email="owner@example.com",
+    )
+
+    try:
+        factory.validate_allowed_identity()
+    except RuntimeError as exc:
+        assert "does not belong to ALLOWED_GMAIL_EMAIL" in str(exc)
+    else:
+        raise AssertionError("expected mismatched owner to be rejected")


### PR DESCRIPTION
## Summary
- remove backend FastMCP GoogleProvider auth so Horizon gateway tokens are accepted
- use a server-owned Google refresh token from env for Gmail API access
- update docs/env example/ADR for Horizon-managed MCP auth

## Verification
- uv run ruff check .
- uv run pytest
- uv run fastmcp inspect main.py:mcp

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PeeeBrain/codesmith/gmail-mcp/pr/3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->